### PR TITLE
removed requierement of tokenizer for running LMEH tasks

### DIFF
--- a/apps/go/manager/records/task.go
+++ b/apps/go/manager/records/task.go
@@ -198,7 +198,7 @@ func CheckTaskDependency(supplierData *SupplierRecord, framework string, task st
 		}
 		if frameworkTaskandStatus[0] == "none" {
 			// No dependencies
-			l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("No dependency: Dependecy OK")
+			l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("No dependency: Dependency OK")
 			continue
 		}
 		taskType, err := GetTaskType(frameworkTaskandStatus[0], frameworkTaskandStatus[1], configMap, l)
@@ -215,15 +215,15 @@ func CheckTaskDependency(supplierData *SupplierRecord, framework string, task st
 			// Check the condition
 			if frameworkTaskandStatus[2] == "present" {
 				// Task is present, so OK
-				l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("Present: Dependecy OK")
+				l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("Present: Dependency OK")
 				continue
 			} else if frameworkTaskandStatus[2] == "ok" {
 				// Check for it having a correct value
 				if thisTaskRecord.IsOK() {
-					l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("OK: Dependecy OK")
+					l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("OK: Dependency OK")
 					continue
 				} else {
-					l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("OK: Dependecy NOT OK")
+					l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("OK: Dependency NOT OK")
 					depOK = false
 					break
 				}

--- a/apps/python/evaluator/workflows/evaluator.py
+++ b/apps/python/evaluator/workflows/evaluator.py
@@ -29,7 +29,7 @@ class Evaluator:
         )
 
         # Perform the corresponding evaluation
-        if framework == "lmeh":
+        if "lmeh" in framework:
             eval_OK, msg_str = await workflow.execute_activity(
                 lmeh_evaluate,
                 args,

--- a/apps/python/sampler/activities/lmeh/sample.py
+++ b/apps/python/sampler/activities/lmeh/sample.py
@@ -185,10 +185,11 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                     **args.llm_args,
                 )
 
-                # first load tokenizer then pass it to be used
+                # first try to load tokenizer then pass it to be used
                 ok = await lm.load_tokenizer()
-
-                if ok:
+                if not ok:
+                    eval_logger.debug("Tokenizer and/or config not available.")
+                try:
                     _ = await lmeh_generator.generate_requests(
                         lm=lm,
                         task_dict=task_dict,
@@ -198,10 +199,8 @@ async def lmeh_sample(args: PocketNetworkTaskRequest) -> bool:
                         timeout_handler=timeout_handler,
                     )
                     eval_logger.info("LM generated successfully.")
-                if not ok:
-                    eval_logger.info(
-                        "Skipped LM generation, tokenizer and/or config not available."
-                    )
+                except ApplicationError as e:
+                    raise e
 
     eval_logger.info("Sample Activity done", task_names=task_names)
     return True

--- a/apps/python/sampler/workflows/register.py
+++ b/apps/python/sampler/workflows/register.py
@@ -15,7 +15,8 @@ class Register:
         eval_logger = get_app_logger("Register")
         eval_logger.info("Starting Workflow Register")
 
-        if args.framework == "lmeh":
+        if "lmeh" in args.framework:
+            # This is a variant of lmeh
             result = await workflow.execute_activity(
                 lmeh_register_task,
                 args,

--- a/apps/python/sampler/workflows/sampler.py
+++ b/apps/python/sampler/workflows/sampler.py
@@ -16,7 +16,7 @@ class Sampler:
         eval_logger = get_app_logger("Sampler")
         eval_logger.info("Starting Workflow Sampler")
 
-        if params.framework == "lmeh":
+        if "lmeh" in params.framework:
             result = await workflow.execute_activity(
                 lmeh_sample,
                 params,

--- a/packages/python/lmeh/pocket_lm_eval/models/pocket_network.py
+++ b/packages/python/lmeh/pocket_lm_eval/models/pocket_network.py
@@ -687,10 +687,12 @@ class EvaluatorLM(TemplateLM):
 
         def _collate(x):
             toks = x[0][1]
-            if toks is None:
-                feat = len(x[0][0])
-            else:
+            if toks is not None:
+                # Normal behavior of lmeh
                 feat = len(toks)
+            else:
+                # Not tokenized input available, we use prompt string length instead
+                feat = len(x[0][0])
             return feat, x[0][0]
 
         re_ord = utils.Reorderer(requests, _collate)

--- a/packages/python/lmeh/utils/mongodb.py
+++ b/packages/python/lmeh/utils/mongodb.py
@@ -136,12 +136,10 @@ class MongoOperator:
         )
 
         if buffer is None:
-            eval_logger.error(
+            eval_logger.debug(
                 f"Buffer for {signature_name} signature not found.", adress=address
             )
-            raise RuntimeError(
-                f"Supplier address {address} does not have a {signature_name} signature buffer associated."
-            )
+            return ""
 
         eval_logger.debug(f"{signature_name} signature buffer found.", buffer=buffer)
 
@@ -191,7 +189,8 @@ class MongoOperator:
         tokenizer_hash = await self.get_tokenizer_hash(address, service)
 
         if tokenizer_hash == "":
-            eval_logger.warn(
+            # This should not be an error if the tokenizer loading is optional
+            eval_logger.debug(
                 "Supplier address does not have a valid tokenizer_hash.", adress=address
             )
             return False, {}
@@ -200,12 +199,11 @@ class MongoOperator:
 
         # Validate that the tokenizer is not empty
         if tokenizer_object is None:
-            eval_logger.error(
-                "Tokenizer hash not found.", address=address, hash=tokenizer_hash
-            )
-            raise RuntimeError(
+            err_str = (
                 f"Tokenizer with hash {tokenizer_hash} does not exist in the database."
             )
+            eval_logger.error(err_str, address=address, hash=tokenizer_hash)
+            raise RuntimeError(err_str)
 
         tokenizer = tokenizer_object["tokenizer"]
         eval_logger.debug("Tokenizer found.", tokenizer_keys=list(tokenizer.keys()))
@@ -218,12 +216,11 @@ class MongoOperator:
         return True, tokenizer
 
     async def get_config_objects(self, address: str, service: str) -> Tuple[bool, dict]:
-        # TODO
-        # add get_config_hash method to
         config_hash = await self.get_config_hash(address, service)
 
         if config_hash == "":
-            eval_logger.warn(
+            # This should not be an error if the configuration loading is optional
+            eval_logger.debug(
                 "Supplier address does not have a valid config_hash.", adress=address
             )
             return False, {}

--- a/tilt/apps/evaluator/local/patches/secret.yaml
+++ b/tilt/apps/evaluator/local/patches/secret.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   config.json: |
     {
-      "log_level": "WARN",
+      "log_level": "DEBUG",
       "postgres_uri": "postgresql://testbench:5iR500QPdHJs9YocKOeSq5DFgevgaQiAWXEtPOtjWsjKrnUFs8@postgresql-service:5432/pocket-ml-testbench",
       "mongodb_uri": "mongodb://mongodb-service:27017/pocket-ml-testbench?replicaSet=devRs&maxPoolSize=500&minPoolSize=50&w=1&journal=false&readConcernLevel=majority&retryWrites=false&connectTimeoutMS=5000&socketTimeoutMS=30000",
       "temporal": {

--- a/tilt/apps/manager/local/patches/secret.template.yaml
+++ b/tilt/apps/manager/local/patches/secret.template.yaml
@@ -42,6 +42,12 @@ stringData:
           "schedule_limits": {"any" : "none:none"},
           "trigger_minimum": {"any" : "0"}
         },
+        "lmeh-generative" : {
+          "task_types": {"any" : "numerical"},
+          "task_dependency": {"any" : ["none:none:none"]},
+          "schedule_limits": {"any" : "none:none"},
+          "trigger_minimum": {"any" : "0"}
+        },
         "helm" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},

--- a/tilt/trigger_tasks.py
+++ b/tilt/trigger_tasks.py
@@ -487,7 +487,7 @@ def main():
 
         # Create per-service tasks
         for chain_id in APPS_PER_SERVICE.keys():
-            print(f"Setting-up chain: {chain_id}")
+            print(f"Triggering signatures for {chain_id}:")
             # Schedule the tokenizer in this service ID
             ok = schedule_tokenizer_task(
                 chain_id, interval="2m", execution_timeout=120, task_timeout=120
@@ -517,6 +517,24 @@ def main():
                 print(f"\t\t{app}")
                 time.sleep(0.25)
         print("Signatures scheduled.")
+
+        # Create per-service tasks
+        for chain_id in APPS_PER_SERVICE.keys():
+            print(f"Triggering requesters for {chain_id} apps':")
+            for app in APPS_PER_SERVICE[chain_id]:
+                print(f"\t{app}")
+                # Schedule the requester using this app
+                ok = schedule_requester_task(
+                    app,
+                    chain_id,
+                    interval="1m",
+                    execution_timeout=350,
+                    task_timeout=175,
+                )
+                total_requesters += ok
+                print(f"\t\t{app}")
+                time.sleep(0.25)
+        print("Requesters scheduled.")
 
         # Create all tasks for all chains
         for task in all_tasks:

--- a/tilt/trigger_tasks.py
+++ b/tilt/trigger_tasks.py
@@ -10,6 +10,8 @@ APPS_PER_SERVICE = {
 
 BASE_COMMAND = ["kubectl", "exec", "-it", "deploy/temporal-admintools"]
 
+LMEH_TYPE = "lmeh"
+
 all_taxonomy_tasks = [
     "mmlu_fix_anatomy_generative",
     "mmlu_fix_medical_genetics_generative",
@@ -355,9 +357,9 @@ def schedule_benchmark_task(
         "schedule",
         "create",
         "--schedule-id",
-        f"lmeh-{benchmark}-{chain_id}",
+        f"{LMEH_TYPE}-{benchmark}-{chain_id}",
         "--workflow-id",
-        f"lmeh-{benchmark}-{chain_id}",
+        f"{LMEH_TYPE}-{benchmark}-{chain_id}",
         "--type",
         "Manager",
         "--task-queue",
@@ -373,7 +375,7 @@ def schedule_benchmark_task(
         "--namespace",
         f"{TEMPORAL_NAMESPACE}",
         "--input",
-        f'{{"service":"{chain_id}","tests":[{{"framework" : "lmeh", "tasks": ["{benchmark}"]}}]}}',
+        f'{{"service":"{chain_id}","tests":[{{"framework" : "{LMEH_TYPE}", "tasks": ["{benchmark}"]}}]}}',
     ]
     return run_command(command)
 
@@ -395,7 +397,7 @@ def execute_register_task(task, execution_timeout=7200, task_timeout=3600):
         "--type",
         "Register",
         "--input",
-        f'{{"framework": "lmeh", "tasks": "{task}"}}',
+        f'{{"framework": "{LMEH_TYPE}", "tasks": "{task}"}}',
         "--execution-timeout",
         f"{execution_timeout}s",
         "--task-timeout",
@@ -417,11 +419,14 @@ def parse_dict_from_string(arg_string):
 
 
 def main():
-    global BASE_COMMAND, TEMPORAL_NAMESPACE, APPS_PER_SERVICE
+    global BASE_COMMAND, TEMPORAL_NAMESPACE, APPS_PER_SERVICE, LMEH_TYPE
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--only-registers", action="store_true", help="Only trigger register tasks"
+    )
+    parser.add_argument(
+        "--generative", action="store_true", help="Use generative LMEH tasks"
     )
     parser.add_argument(
         "--task", help="optionally pass a task identifier, e.g. --task ifeval-fix"
@@ -464,6 +469,9 @@ def main():
         print(f"Triggering only: {args.task}")
         all_tasks = [args.task]
 
+    if args.generative:
+        LMEH_TYPE += "-generative"
+
     if args.only_registers:
         print("Setting-up registers only:")
         for task in all_tasks:
@@ -486,37 +494,38 @@ def main():
         time.sleep(0.25)
 
         # Create per-service tasks
-        for chain_id in APPS_PER_SERVICE.keys():
-            print(f"Triggering signatures for {chain_id}:")
-            # Schedule the tokenizer in this service ID
-            ok = schedule_tokenizer_task(
-                chain_id, interval="2m", execution_timeout=120, task_timeout=120
-            )
-            print("\tTokenizer triggered.")
-            time.sleep(0.25)
-            total_tokenizers += ok
-            # Schedule the config task in this Service ID
-            ok = schedule_config_task(
-                chain_id, interval="2m", execution_timeout=120, task_timeout=120
-            )
-            print("\tConfiguration triggered.")
-            time.sleep(0.25)
-            total_configs += ok
-            # Schedule a requester for each app in this service ID
-            print("\tTriggering requesters for apps:")
-            for app in APPS_PER_SERVICE[chain_id]:
-                # Schedule the requester using this app
-                ok = schedule_requester_task(
-                    app,
-                    chain_id,
-                    interval="1m",
-                    execution_timeout=350,
-                    task_timeout=175,
+        if not args.generative:
+            for chain_id in APPS_PER_SERVICE.keys():
+                print(f"Triggering signatures for {chain_id}:")
+                # Schedule the tokenizer in this service ID
+                ok = schedule_tokenizer_task(
+                    chain_id, interval="2m", execution_timeout=120, task_timeout=120
                 )
-                total_requesters += ok
-                print(f"\t\t{app}")
+                print("\tTokenizer triggered.")
                 time.sleep(0.25)
-        print("Signatures scheduled.")
+                total_tokenizers += ok
+                # Schedule the config task in this Service ID
+                ok = schedule_config_task(
+                    chain_id, interval="2m", execution_timeout=120, task_timeout=120
+                )
+                print("\tConfiguration triggered.")
+                time.sleep(0.25)
+                total_configs += ok
+                # Schedule a requester for each app in this service ID
+                print("\tTriggering requesters for apps:")
+                for app in APPS_PER_SERVICE[chain_id]:
+                    # Schedule the requester using this app
+                    ok = schedule_requester_task(
+                        app,
+                        chain_id,
+                        interval="1m",
+                        execution_timeout=350,
+                        task_timeout=175,
+                    )
+                    total_requesters += ok
+                    print(f"\t\t{app}")
+                    time.sleep(0.25)
+            print("Signatures scheduled.")
 
         # Create per-service tasks
         for chain_id in APPS_PER_SERVICE.keys():


### PR DESCRIPTION
Here we include:
- Removal of `tokenizer` and `config` signatures for running `LMEH` tasks. It is the user's responsibility not to select tasks that need metrics like log-llikelhood over tokens, such tasks will result in errors at evaluation time.
- Now the `lmeh` framework can have multiple sub-types. A framework sub-type is simply any framework that includes the `lmeh` string in its name.
- If no config is available, the max-length defaults to `8192` tokens.
- The length of the prompt (in tokens), used to estimate the timeout of the request, is estimated as `number of words / 0.75`.
- Modified TILT files: 
  - `Evaluator` app is now properly set to DEBUG logs.
  - Added new framework `lmeh-generative` used for tokenizer-free tests.
  - Task triggering had small fixes in prints order and clarity.