### PR TITLE
150 manager add taxonomy requierement

### DIFF
--- a/apps/go/manager/README.md
+++ b/apps/go/manager/README.md
@@ -20,4 +20,4 @@ The trigger process must include limits to avoid clogging the Requester app:
 1. Check db for how many are in queue for a given supplier.
 2. Add as many as it can until the given limit using round-robin on metrics.
 3. Trigger tasks periodically
-4. Check for tasks requirements (such as having a tokenizer signature).
+4. Check for tasks requirements (such as having a tokenizer signature or meet a taxonomy result dependency).

--- a/apps/go/manager/activities/process_supplier_result.go
+++ b/apps/go/manager/activities/process_supplier_result.go
@@ -87,9 +87,9 @@ func (aCtx *Ctx) AnalyzeResult(ctx context.Context, params types.AnalyzeResultPa
 	if err != nil {
 		return nil, err
 	}
-	thisTaskRecord, found := records.GetTaskData(supplierData.ID, taskType, taskData.Framework, taskData.Task, aCtx.App.Mongodb, l)
-
+	thisTaskRecord, found := records.GetTaskData(supplierData.ID, taskType, taskData.Framework, taskData.Task, true, aCtx.App.Mongodb, l)
 	if !found {
+		// Data should be found because we are creating it in the last call...
 		err = temporal.NewApplicationErrorWithCause("unable to get task data", "GetTaskData", fmt.Errorf("Task %s not found", taskData.Task))
 		l.Error().
 			Str("address", supplierData.Address).

--- a/apps/go/manager/config.sample.json
+++ b/apps/go/manager/config.sample.json
@@ -34,23 +34,47 @@
     }
   },
   "frameworks": {
+    "lmeh-liveness" : {
+      "task_types": {"any" : "numerical"},
+      "task_dependency": {"any" : ["none:none:none"]},
+      "schedule_limits": {"any" : "none:none"},
+      "trigger_minimum": {"any" : "0"},
+      "taxonomy_dependency": {"any" : ["none:none:none:none"]}
+    },
+    "lmeh-base" : {
+      "task_types": {"any" : "numerical"},
+      "task_dependency": {"any" : ["none:none:none"]},
+      "schedule_limits": {"any" : "none:none"},
+      "trigger_minimum": {"any" : "0"},
+      "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
+    },
+    "lmeh-generative" : {
+      "task_types": {"any" : "numerical"},
+      "task_dependency": {"any" : ["none:none:none"]},
+      "schedule_limits": {"any" : "none:none"},
+      "trigger_minimum": {"any" : "0"},
+      "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10", "babisteps_v0:0.5:0.8:10"]}
+    },
     "lmeh" : {
       "task_types": {"any" : "numerical"},
       "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
       "schedule_limits": {"any" : "none:none"},
-      "trigger_minimum": {"any" : "0"}
+      "trigger_minimum": {"any" : "0"},
+      "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
     },
     "helm" : {
       "task_types": {"any" : "numerical"},
       "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
       "schedule_limits": {"any" : "none:none"},
-      "trigger_minimum": {"any" : "0"}
+      "trigger_minimum": {"any" : "0"},
+      "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
     },
     "signatures" : {
       "task_types": {"any" : "signature"},
       "task_dependency": {"any" : ["none:none:none"]},
       "schedule_limits": {"any" : "1:session"},
-      "trigger_minimum": {"tokenizer" : "1", "config" : "1"}
+      "trigger_minimum": {"tokenizer" : "1", "config" : "1"},
+      "taxonomy_dependency": {"any" : ["none:none:none:none"]}
     }
   },
   "external_suppliers" : ["external_some_name"]

--- a/apps/go/manager/records/supplier.go
+++ b/apps/go/manager/records/supplier.go
@@ -93,8 +93,7 @@ func (record *SupplierRecord) Init(
 
 	record.ID = hashObjectId
 	record.LastSeenHeight = 0
-	defaultDate := time.Date(2018, 1, 1, 00, 00, 00, 100, time.Local)
-	record.LastSeenTime = defaultDate
+	record.LastSeenTime = time.Now().UTC()
 
 	_, err = record.UpdateSupplier(mongoDB, l)
 

--- a/apps/go/manager/records/supplier.go
+++ b/apps/go/manager/records/supplier.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"manager/types"
 	"packages/mongodb"
 	"time"
@@ -66,23 +65,10 @@ func (record *SupplierRecord) FindAndLoadSupplier(supplier types.SupplierData, m
 	return found, nil
 }
 
-func (record *SupplierRecord) AppendTask(supplierID primitive.ObjectID, framework string, task string, date time.Time, frameworkConfigMap map[string]types.FrameworkConfig, mongoDB mongodb.MongoDb, l *zerolog.Logger) TaskInterface {
-
-	taskType, err := GetTaskType(framework, task, frameworkConfigMap, l)
-	if err != nil {
-		return nil
-	}
-	// Get the task, wich will create it if not found
-	taskRecord, found := GetTaskData(supplierID, taskType, framework, task, mongoDB, l)
-	if !found {
-		return nil
-	} else {
-		return taskRecord
-	}
-
-}
-
-func (record *SupplierRecord) Init(params types.AnalyzeSupplierParams, frameworkConfigMap map[string]types.FrameworkConfig, mongoDB mongodb.MongoDb, l *zerolog.Logger) error {
+func (record *SupplierRecord) Init(
+	params types.AnalyzeSupplierParams,
+	frameworkConfigMap map[string]types.FrameworkConfig,
+	mongoDB mongodb.MongoDb, l *zerolog.Logger) error {
 	// Initialize empty record
 
 	// Set supplier data
@@ -109,18 +95,6 @@ func (record *SupplierRecord) Init(params types.AnalyzeSupplierParams, framework
 	record.LastSeenHeight = 0
 	defaultDate := time.Date(2018, 1, 1, 00, 00, 00, 100, time.Local)
 	record.LastSeenTime = defaultDate
-
-	// Create all tests
-	if len(params.Tests) == 0 {
-		return errors.New(`tests array cannot be empty`)
-	}
-	for _, test := range params.Tests {
-
-		for _, task := range test.Tasks {
-			// Add all tasks with the current date as maker for creation
-			_ = record.AppendTask(record.ID, test.Framework, task, time.Now(), frameworkConfigMap, mongoDB, l)
-		}
-	}
 
 	_, err = record.UpdateSupplier(mongoDB, l)
 

--- a/apps/go/manager/records/task.go
+++ b/apps/go/manager/records/task.go
@@ -93,7 +93,7 @@ type TaskInterface interface {
 	UpdateTask(supplierID primitive.ObjectID, framework string, task string, mongoDB mongodb.MongoDb, l *zerolog.Logger) (bool, error)
 }
 
-// Get specific task data from a supplier record
+// Get specific taxonomy data from a supplier record
 func GetTaxonomyData(
 	supplierID primitive.ObjectID,
 	taxonomy string,

--- a/apps/go/manager/records/task.go
+++ b/apps/go/manager/records/task.go
@@ -94,7 +94,48 @@ type TaskInterface interface {
 }
 
 // Get specific task data from a supplier record
-func GetTaskData(supplierID primitive.ObjectID, taskType string, framework string, task string, mongoDB mongodb.MongoDb, l *zerolog.Logger) (TaskInterface, bool) {
+func GetTaxonomyData(
+	supplierID primitive.ObjectID,
+	taxonomy string,
+	mongoDB mongodb.MongoDb,
+	l *zerolog.Logger) (taxonomySummary types.TaxonomySummary, found bool) {
+
+	task_filter := bson.D{
+		{Key: "supplier_id", Value: supplierID},
+		{Key: "taxonomy_name", Value: taxonomy},
+	}
+	taxonomyCollection := mongoDB.GetCollection(types.TaxonomySummariesCollection)
+	opts := options.FindOne()
+
+	// Set mongo context
+	ctxM, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Retrieve this supplier entry
+	found = true
+	cursor := taxonomyCollection.FindOne(ctxM, task_filter, opts)
+	err := cursor.Decode(&taxonomySummary)
+	if err != nil {
+		found = false
+		if err == mongo.ErrNoDocuments {
+			l.Warn().Str("supplier_id", supplierID.String()).Str("taxonomy", taxonomy).Msg("Taxonomy summary not found")
+		} else {
+			l.Error().Err(err).Str("supplierID", supplierID.String()).Str("taxonomy", taxonomy).Msg("Could not retrieve taxonomy summary data from MongoDB")
+		}
+	}
+	return taxonomySummary, found
+
+}
+
+// Get specific task data from a supplier record
+func GetTaskData(
+	supplierID primitive.ObjectID,
+	taskType string,
+	framework string,
+	task string,
+	create_new bool,
+	mongoDB mongodb.MongoDb,
+	l *zerolog.Logger) (TaskInterface, bool) {
 
 	// Look for entry
 	if taskType == NumericalTaskTypeName {
@@ -106,9 +147,13 @@ func GetTaskData(supplierID primitive.ObjectID, taskType string, framework strin
 			return nil, false
 		}
 		if !found {
-			// Initialize and save
-			record.NewTask(supplierID, framework, task, types.EpochStart.UTC(), l)
-			record.UpdateTask(supplierID, framework, task, mongoDB, l)
+			if create_new {
+				// Initialize and save
+				record.NewTask(supplierID, framework, task, types.EpochStart.UTC(), l)
+				record.UpdateTask(supplierID, framework, task, mongoDB, l)
+			} else {
+				return nil, false
+			}
 		}
 		return &record, true
 	} else if taskType == SignatureTaskTypeName {
@@ -120,9 +165,13 @@ func GetTaskData(supplierID primitive.ObjectID, taskType string, framework strin
 			return nil, false
 		}
 		if !found {
-			// Initialize and save
-			record.NewTask(supplierID, framework, task, types.EpochStart.UTC(), l)
-			record.UpdateTask(supplierID, framework, task, mongoDB, l)
+			if create_new {
+				// Initialize and save
+				record.NewTask(supplierID, framework, task, types.EpochStart.UTC(), l)
+				record.UpdateTask(supplierID, framework, task, mongoDB, l)
+			} else {
+				return nil, false
+			}
 		}
 		return &record, true
 	}
@@ -155,6 +204,104 @@ func GetTaskType(framework string, task string, configMap map[string]types.Frame
 	}
 
 	return taskType, nil
+}
+
+// Analyzes the taxonomy dependencies and returns if it is possible to proceed with this task triggering/analysis
+// A task can depend on some taxonomies to be passed at a certain level, here we check for that
+func CheckTaxonomyDependency(
+	supplierData *SupplierRecord,
+	framework string,
+	task string,
+	configMap map[string]types.FrameworkConfig,
+	mongoDB mongodb.MongoDb, l *zerolog.Logger) (bool, error) {
+
+	// Get Framework config
+	frameworkCfg, ok := configMap[framework]
+	if !ok {
+		l.Error().Str("framework", framework).Msg("framework config not found")
+		err := fmt.Errorf("framework config not found")
+		return false, err
+	}
+
+	// Get taxonomy dependency
+	taskDep, ok := frameworkCfg.TaxonomyDependency[task]
+	if !ok {
+		// Search for the "any" field
+		taskDep, ok = frameworkCfg.TaxonomyDependency["any"]
+		if !ok {
+			l.Error().Str("framework", framework).Str("task", task).Msg("cannot find default (or specific) value for task type")
+			err := fmt.Errorf("cannot find default (or specific) value for task type")
+			return false, err
+		}
+		if len(taskDep) == 0 {
+			l.Error().Str("framework", framework).Str("task", task).Msg("malformed dependency array for task type")
+			err := fmt.Errorf("malformed dependency array for task type")
+			return false, err
+		}
+	}
+
+	// Check dependency
+	depOK := true
+	for idxDep := 0; idxDep < len(taskDep); idxDep++ {
+		// get data from entry
+		frameworkTaxonomyAndStatus := strings.Split(taskDep[idxDep], ":")
+		if len(frameworkTaxonomyAndStatus) != 4 {
+			l.Error().Str("framework", framework).Str("task", task).Msg("malformed taxonomy dependency configuration, expected four elements separated by \":\" ")
+			depOK = false
+			break
+		}
+		if frameworkTaxonomyAndStatus[0] == "none" {
+			// No dependencies
+			l.Debug().Str("address", supplierData.Address).Str("service", supplierData.Service).Str("framework", framework).Str("task", task).Msg("No taxonomy dependency: Dependency OK")
+			continue
+		}
+		// All other three must be numerical entries
+		scoreMin, err := strconv.ParseFloat(frameworkTaxonomyAndStatus[1], 64)
+		if err != nil {
+			l.Error().Str("framework", framework).Str("task", task).Str("taxonomy", frameworkTaxonomyAndStatus[0]).Msg("malformed taxonomy dependency configuration, cannot convert string to float for first element.")
+			depOK = false
+			break
+		}
+		// TODO : Implement success rate tracking
+		// successRateMin, err := strconv.ParseFloat(frameworkTaxonomyAndStatus[2], 64)
+		// if err != nil {
+		// 	l.Error().Str("framework", framework).Str("task", task).Str("taxonomy", frameworkTaxonomyAndStatus[0]).Msg("malformed taxonomy dependency configuration, cannot convert string to float for second element.")
+		// 	depOK = false
+		// 	break
+		// }
+		samplesMin, err := strconv.ParseFloat(frameworkTaxonomyAndStatus[3], 64)
+		if err != nil {
+			l.Error().Str("framework", framework).Str("task", task).Str("taxonomy", frameworkTaxonomyAndStatus[0]).Msg("malformed taxonomy dependency configuration, cannot convert string to float for third element.")
+			depOK = false
+			break
+		}
+
+		// Get the taxonomy to evaluate
+		thisTaxonomySummary, found := GetTaxonomyData(supplierData.ID, frameworkTaxonomyAndStatus[0], mongoDB, l)
+		if !found {
+			// The task is not even created, we must fail
+			depOK = false
+			break
+		} else {
+			// Check the condition over the root_c node
+			taxonomyRootNode, found := thisTaxonomySummary.TaxonomyNodesScores["root_c"]
+			if !found {
+				l.Error().Str("framework", framework).Str("task", task).Str("taxonomy", frameworkTaxonomyAndStatus[0]).Msg("malformed taxonomy summary, no root_c node!")
+				depOK = false
+				break
+			}
+
+			if (taxonomyRootNode.Score < scoreMin) ||
+				// (taxonomyRootNode.ErrorRate > (1-successRateMin)) ||
+				(float64(taxonomyRootNode.SampleMin) < samplesMin) {
+				// Condition not met
+				depOK = false
+				break
+			}
+		}
+	}
+
+	return depOK, nil
 }
 
 // Analyzes the configuration and returns if it is possible to proceed with this task triggering/analysis
@@ -206,7 +353,7 @@ func CheckTaskDependency(supplierData *SupplierRecord, framework string, task st
 			l.Error().Str("framework", framework).Str("task", task).Str("task type", taskType).Msg("Error getting task type")
 			return false, err
 		}
-		thisTaskRecord, found := GetTaskData(supplierData.ID, taskType, frameworkTaskandStatus[0], frameworkTaskandStatus[1], mongoDB, l)
+		thisTaskRecord, found := GetTaskData(supplierData.ID, taskType, frameworkTaskandStatus[0], frameworkTaskandStatus[1], false, mongoDB, l)
 		if !found {
 			// The task is not even created, we must fail
 			depOK = false
@@ -405,7 +552,7 @@ func (record *NumericalTaskRecord) NewTask(supplierID primitive.ObjectID, framew
 	record.TaskData.SupplierID = supplierID
 	record.TaskData.Framework = framework
 	record.TaskData.Task = task
-	record.TaskData.LastSeen = date
+	record.TaskData.LastSeen = time.Now().UTC()
 
 	record.MeanScore = 0.0
 	record.MedianScore = 0.0

--- a/apps/go/manager/types/app_config.go
+++ b/apps/go/manager/types/app_config.go
@@ -18,4 +18,5 @@ type App struct {
 	PocketBlocksPerSession int64
 	TemporalClient         client.Client
 	ExternalSuppliers      []string
+	TaxonomyTasks          map[string]string
 }

--- a/apps/go/manager/types/app_config.go
+++ b/apps/go/manager/types/app_config.go
@@ -18,5 +18,4 @@ type App struct {
 	PocketBlocksPerSession int64
 	TemporalClient         client.Client
 	ExternalSuppliers      []string
-	TaxonomyTasks          map[string]string
 }

--- a/apps/go/manager/types/config.go
+++ b/apps/go/manager/types/config.go
@@ -237,10 +237,11 @@ type Config struct {
 }
 
 type FrameworkConfig struct {
-	TasksTypes      map[string]string   `json:"task_types"`
-	TasksDependency map[string][]string `json:"task_dependency"`
-	ScheduleLimits  map[string]string   `json:"schedule_limits"`
-	TriggerMinimum  map[string]string   `json:"trigger_minimum"`
+	TasksTypes         map[string]string   `json:"task_types"`
+	TasksDependency    map[string][]string `json:"task_dependency"`
+	ScheduleLimits     map[string]string   `json:"schedule_limits"`
+	TriggerMinimum     map[string]string   `json:"trigger_minimum"`
+	TaxonomyDependency map[string][]string `json:"taxonomy_dependency"`
 }
 
 type DevelopConfig struct {

--- a/apps/go/manager/types/mongodb.go
+++ b/apps/go/manager/types/mongodb.go
@@ -1,12 +1,13 @@
 package types
 
 var (
-	TaskCollection           = "tasks"
-	InstanceCollection       = "instances"
-	PromptsCollection        = "prompts"
-	ResponsesCollection      = "responses"
-	SuppliersCollection      = "suppliers"
-	ResultsCollection        = "results"
-	NumericalTaskCollection  = "buffers_numerical"
-	SignaturesTaskCollection = "buffers_signatures"
+	TaskCollection              = "tasks"
+	InstanceCollection          = "instances"
+	PromptsCollection           = "prompts"
+	ResponsesCollection         = "responses"
+	SuppliersCollection         = "suppliers"
+	ResultsCollection           = "results"
+	NumericalTaskCollection     = "buffers_numerical"
+	SignaturesTaskCollection    = "buffers_signatures"
+	TaxonomySummariesCollection = "taxonomy_summaries"
 )

--- a/apps/go/manager/types/taxonomies.go
+++ b/apps/go/manager/types/taxonomies.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type TaxonomyNode struct {
+	Score      float64 `bson:"score"`
+	ScoreDev   float64 `bson:"score_dev"`
+	RunTime    float64 `bson:"run_time"`
+	RunTimeDev float64 `bson:"run_time_dev"`
+	SampleMin  int64   `bson:"sample_min"`
+}
+
+type TaxonomySummary struct {
+	SupplierID          primitive.ObjectID      `bson:"supplier_id"`
+	SummaryDate         time.Time               `bson:"summary_date"`
+	TaxonomyName        string                  `bson:"taxonomy_name"`
+	TaxonomyNodesScores map[string]TaxonomyNode `bson:"taxonomy_nodes_scores"`
+}

--- a/apps/go/manager/x/app.go
+++ b/apps/go/manager/x/app.go
@@ -92,6 +92,7 @@ func Initialize() *types.App {
 		types.ResponsesCollection,
 		types.NumericalTaskCollection,
 		types.SignaturesTaskCollection,
+		types.TaxonomySummariesCollection,
 	}, l)
 
 	// Create LazyNode
@@ -138,7 +139,7 @@ func Initialize() *types.App {
 		Str("TaskQueue", cfg.Temporal.TaskQueue).
 		Msg("Successfully connected to Temporal Server")
 
-	// Create instance of App data
+		// Create instance of App data
 	ac := &types.App{
 		Logger:                 l,
 		Config:                 cfg,

--- a/apps/python/summarizer/activities/summarize_taxonomy.py
+++ b/apps/python/summarizer/activities/summarize_taxonomy.py
@@ -119,7 +119,7 @@ async def summarize_taxonomy(
             f"No data to process summary for {args.supplier_id} in taxonomy {args.taxonomy}"
         )
         return True, "No data to summarize"
-    
+
     # Calculate root (grand average)
     running_score_total = 0
     running_score_square_dev = 0
@@ -159,7 +159,10 @@ async def summarize_taxonomy(
                 await mongo_client.db[
                     mongo_operator.taxonomy_summaries
                 ].find_one_and_replace(
-                    {"supplier_id": ObjectId(args.supplier_id), "taxonomy_name": args.taxonomy},
+                    {
+                        "supplier_id": ObjectId(args.supplier_id),
+                        "taxonomy_name": args.taxonomy,
+                    },
                     result_dump,
                     upsert=True,
                     return_document=False,

--- a/packages/python/lmeh/utils/mongo_aggrs.py
+++ b/packages/python/lmeh/utils/mongo_aggrs.py
@@ -106,7 +106,7 @@ def aggregate_supplier_task_results(supplier_id: ObjectId, framework: str, task:
         {
             "$match": {
                 "task_data.supplier_id": supplier_id,
-                "task_data.framework": framework,
+                "task_data.framework": { "$regex": framework, "$options": "i" },
                 "task_data.task": task,
             }
         },

--- a/packages/python/lmeh/utils/mongo_aggrs.py
+++ b/packages/python/lmeh/utils/mongo_aggrs.py
@@ -106,7 +106,7 @@ def aggregate_supplier_task_results(supplier_id: ObjectId, framework: str, task:
         {
             "$match": {
                 "task_data.supplier_id": supplier_id,
-                "task_data.framework": { "$regex": framework, "$options": "i" },
+                "task_data.framework": {"$regex": framework, "$options": "i"},
                 "task_data.task": task,
             }
         },

--- a/taxonomies/liveness_v0.tax
+++ b/taxonomies/liveness_v0.tax
@@ -1,0 +1,10 @@
+// This is a simple taxonomy that should tell us if a black box has bare minimum
+// language capabilities
+
+liveness_v0 {
+    root_c -> liveness;
+}
+
+liveness_v0_labeling {
+    liveness -> babi-task_01-single_supporting_fact;
+}

--- a/tilt/apps/manager/base/secret.yaml
+++ b/tilt/apps/manager/base/secret.yaml
@@ -36,23 +36,33 @@ stringData:
         }
       },
       "frameworks": {
+        "lmeh-liveness" : {
+          "task_types": {"any" : "numerical"},
+          "task_dependency": {"any" : ["none:none:none"]},
+          "schedule_limits": {"any" : "none:none"},
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : ["none:none:none:none"]}
+        },
         "lmeh" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
           "schedule_limits": {"any" : "none:none"},
-          "trigger_minimum": {"any" : "0"}
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : [""liveness_v0:0.8:0.8:10"]}
         },
         "helm" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
           "schedule_limits": {"any" : "none:none"},
-          "trigger_minimum": {"any" : "0"}
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : [""liveness_v0:0.8:0.8:10"]}
         },
         "signatures" : {
           "task_types": {"any" : "signature"},
           "task_dependency": {"any" : ["none:none:none"]},
           "schedule_limits": {"any" : "1:session"},
-          "trigger_minimum": {"tokenizer" : "1", "config" : "1"}
+          "trigger_minimum": {"tokenizer" : "1", "config" : "1"},
+          "taxonomy_dependency": {"any" : ["none:none:none:none"]}
         }
       },
       "external_suppliers" : ["external_some_name"]

--- a/tilt/apps/manager/local/patches/secret.template.yaml
+++ b/tilt/apps/manager/local/patches/secret.template.yaml
@@ -36,29 +36,40 @@ stringData:
         }
       },
       "frameworks": {
+        "lmeh-liveness" : {
+          "task_types": {"any" : "numerical"},
+          "task_dependency": {"any" : ["none:none:none"]},
+          "schedule_limits": {"any" : "none:none"},
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : ["none:none:none:none"]}
+        },
         "lmeh" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
           "schedule_limits": {"any" : "none:none"},
-          "trigger_minimum": {"any" : "0"}
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
         },
         "lmeh-generative" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["none:none:none"]},
           "schedule_limits": {"any" : "none:none"},
-          "trigger_minimum": {"any" : "0"}
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
         },
         "helm" : {
           "task_types": {"any" : "numerical"},
           "task_dependency": {"any" : ["signatures:tokenizer:ok", "signatures:config:ok"]},
           "schedule_limits": {"any" : "none:none"},
-          "trigger_minimum": {"any" : "0"}
+          "trigger_minimum": {"any" : "0"},
+          "taxonomy_dependency": {"any" : ["liveness_v0:0.8:0.8:10"]}
         },
         "signatures" : {
           "task_types": {"any" : "signature"},
           "task_dependency": {"any" : ["none:none:none"]},
           "schedule_limits": {"any" : "1:session"},
-          "trigger_minimum": {"tokenizer" : "1", "config" : "1"}
+          "trigger_minimum": {"tokenizer" : "1", "config" : "1"},
+          "taxonomy_dependency": {"any" : ["none:none:none:none"]}
         }
       },
       "external_suppliers" : $EXT_SUPPLIERS_TRACK

--- a/tilt/dependencies/temporal-ui/base/deployment.yaml
+++ b/tilt/dependencies/temporal-ui/base/deployment.yaml
@@ -29,6 +29,11 @@ spec:
                 secretKeyRef:
                   name: temporal-secret
                   key: TEMPORAL_CORS_ORIGINS
+            - name: TEMPORAL_CSRF_COOKIE_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: temporal-secret
+                  key: TEMPORAL_CSRF_COOKIE_INSECURE
             - name: TEMPORAL_DEFAULT_NAMESPACE
               valueFrom:
                 secretKeyRef:

--- a/tilt/dependencies/temporal/base/secret.yaml
+++ b/tilt/dependencies/temporal/base/secret.yaml
@@ -9,3 +9,4 @@ stringData:
   TEMPORAL_NAMESPACE: pocket-ml-testbench
   DB: postgres12
   TEMPORAL_CORS_ORIGINS: http://localhost:8000
+  TEMPORAL_CSRF_COOKIE_INSECURE: "true"

--- a/tilt/trigger_tasks.py
+++ b/tilt/trigger_tasks.py
@@ -443,6 +443,9 @@ def main():
         type=parse_dict_from_string,
         help='A dictionary in JSON format (e.g., \'{"lm": ["pokt1wkra80yv9zv69y2rgkmc69jfqph6053dwn47vx"]}\')',
     )
+    parser.add_argument(
+        "--framework-postfix", help="Optional: Framework postfix to use, the final framework name will be \"lmeh-THISVALUE\""
+    )
 
     args = parser.parse_args()
 
@@ -469,7 +472,9 @@ def main():
         print(f"Triggering only: {args.task}")
         all_tasks = [args.task]
 
-    if args.generative:
+    if args.framework_postfix:
+        LMEH_TYPE += "-" + args.framework_postfix
+    elif args.generative:
         LMEH_TYPE += "-generative"
 
     if args.only_registers:

--- a/tilt/trigger_tasks.py
+++ b/tilt/trigger_tasks.py
@@ -444,7 +444,8 @@ def main():
         help='A dictionary in JSON format (e.g., \'{"lm": ["pokt1wkra80yv9zv69y2rgkmc69jfqph6053dwn47vx"]}\')',
     )
     parser.add_argument(
-        "--framework-postfix", help="Optional: Framework postfix to use, the final framework name will be \"lmeh-THISVALUE\""
+        "--framework-postfix",
+        help='Optional: Framework postfix to use, the final framework name will be "lmeh-THISVALUE"',
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR includes:
- Fix of Summarizer logic to low for any task of the `lmeh` framework.
- New filter to avoid entries in the DB when the taxonomy has less than one node with valid data.
- Fixed initial date of signatures and numerical buffers to be the one of creation (instead 1970).
- Fixed the numerical/signature buffer creation to only create the instances if the checks (task or taxonomy dependencies) have passed to avoid DB pollution.
- Added new mechanism to make a framework depend on the result of a taxonomy. This is used to have framework tiers, making, for example `lmeh-generative` depend on `lmeh-liveness` to avoid unnecessary calls to dead/unresponsive nodes.
- Now the `lmeh` framework can have sub-groups, like `lmeh-generative` or `lmeh-random`, the string `lmeh` is the only identification needed to keep the sampling and evaluation logic working.
- Added new taxonomy `liveness_v0` that has a single simple task (`babi task 1`) and it is used as basic test to check if a node is live.


The result of this PR should enable us to apply TTL to MongoDB records and reduce the overall amount of entries in the DB and also radically reduce the amount of requests done to unresponsive suppliers.